### PR TITLE
Add basic Mapbox Expressions mappings

### DIFF
--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -20,7 +20,17 @@ object deps {
     const val junit = "junit:junit:4.13"
 
     object kotlin {
-        const val junit = "org.jetbrains.kotlin:kotlin-test-junit"
+        const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib:${Versions.kotlin}"
+        const val stdlibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:${Versions.kotlin}"
+        const val stdlibJs = "org.jetbrains.kotlin:kotlin-stdlib-js:${Versions.kotlin}"
+        const val xcode = "org.jetbrains.kotlin.native.xcode:kotlin-native-xcode-11-4-workaround:1.3.72.0"
+
+        object test {
+            const val common = "org.jetbrains.kotlin:kotlin-test-common"
+            const val annotationsCommon = "org.jetbrains.kotlin:kotlin-test-annotations-common"
+            const val junit = "org.jetbrains.kotlin:kotlin-test-junit"
+            const val js = "org.jetbrains.kotlin:kotlin-test-js"
+        }
     }
 
     object sqldelight {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -82,7 +82,7 @@ kotlin {
     }
 
     sourceSets["androidTest"].dependencies {
-        implementation(deps.kotlin.junit)
+        implementation(deps.kotlin.test.junit)
         implementation(deps.sqldelight.sqliteDriver)
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,6 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+kotlin.mpp.enableGranularSourceSetsMetadata=true
+kotlin.native.enableDependencyPropagation=false

--- a/mapbox/build.gradle.kts
+++ b/mapbox/build.gradle.kts
@@ -40,7 +40,31 @@ kotlin {
     }
     ios()
 
+    sourceSets["commonMain"].dependencies {
+        implementation(deps.kotlin.stdlibCommon)
+    }
+
+    sourceSets["commonTest"].dependencies {
+        implementation(deps.kotlin.test.common)
+        implementation(deps.kotlin.test.annotationsCommon)
+    }
+
     sourceSets["androidMain"].dependencies {
+        implementation(deps.kotlin.stdlib)
         implementation(deps.mapbox.androidSdk)
+    }
+
+    sourceSets["androidTest"].dependencies {
+        implementation(deps.kotlin.test.junit)
+        implementation(deps.kotlin.test.annotationsCommon)
+    }
+
+    sourceSets["jsMain"].dependencies {
+        implementation(deps.kotlin.stdlibJs)
+    }
+
+    sourceSets["jsTest"].dependencies {
+        implementation(deps.kotlin.test.js)
+        implementation(deps.kotlin.test.annotationsCommon)
     }
 }

--- a/mapbox/src/androidMain/kotlin/com/cuhacking/mapbox/expressions/Expression.kt
+++ b/mapbox/src/androidMain/kotlin/com/cuhacking/mapbox/expressions/Expression.kt
@@ -1,0 +1,9 @@
+package com.cuhacking.mapbox.expressions
+
+import com.mapbox.mapboxsdk.style.expressions.Expression as MapboxExpression
+import com.mapbox.mapboxsdk.style.expressions.Expression.ExpressionLiteral as MapboxExpressionLiteral
+
+fun Expression.toMapbox(): MapboxExpression = when (this) {
+    is ExpressionLiteral -> MapboxExpressionLiteral(literal)
+    else -> MapboxExpression(operator!!, *arguments.map(Expression::toMapbox).toTypedArray())
+}

--- a/mapbox/src/androidTest/kotlin/com/cuhacking/mapbox/expressions/ExpressionLiteralTests.kt
+++ b/mapbox/src/androidTest/kotlin/com/cuhacking/mapbox/expressions/ExpressionLiteralTests.kt
@@ -1,23 +1,9 @@
 package com.cuhacking.mapbox.expressions
 
 import com.mapbox.mapboxsdk.style.expressions.Expression
-import kotlin.test.Test
-import kotlin.test.assertEquals
 
-actual class ExpressionLiteralTests {
-    @Test
-    actual fun testLiteralNumberMapping() {
-        val value = literal(64)
-        val mapbox = Expression.literal(64)
+actual object Literals {
+    actual fun number(number: Number): Any = Expression.literal(number)
 
-        assertEquals(value.toMapbox(), mapbox)
-    }
-
-    @Test
-    actual fun testLiteralStringMapping() {
-        val value = literal("Hello World")
-        val mapbox = Expression.literal("Hello World")
-
-        assertEquals(value.toMapbox(), mapbox)
-    }
+    actual fun string(string: String): Any = Expression.literal(string)
 }

--- a/mapbox/src/androidTest/kotlin/com/cuhacking/mapbox/expressions/ExpressionLiteralTests.kt
+++ b/mapbox/src/androidTest/kotlin/com/cuhacking/mapbox/expressions/ExpressionLiteralTests.kt
@@ -1,0 +1,23 @@
+package com.cuhacking.mapbox.expressions
+
+import com.mapbox.mapboxsdk.style.expressions.Expression
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+actual class ExpressionLiteralTests {
+    @Test
+    actual fun testLiteralNumberMapping() {
+        val value = literal(64)
+        val mapbox = Expression.literal(64)
+
+        assertEquals(value.toMapbox(), mapbox)
+    }
+
+    @Test
+    actual fun testLiteralStringMapping() {
+        val value = literal("Hello World")
+        val mapbox = Expression.literal("Hello World")
+
+        assertEquals(value.toMapbox(), mapbox)
+    }
+}

--- a/mapbox/src/androidTest/kotlin/com/cuhacking/mapbox/test/assertMapboxEquivalent.kt
+++ b/mapbox/src/androidTest/kotlin/com/cuhacking/mapbox/test/assertMapboxEquivalent.kt
@@ -1,0 +1,21 @@
+package com.cuhacking.mapbox.test
+
+import com.cuhacking.mapbox.expressions.Expression
+import com.cuhacking.mapbox.expressions.toMapbox
+import kotlin.test.assertEquals
+import com.mapbox.mapboxsdk.style.expressions.Expression as MapboxExpression
+
+/**
+ * Utility assertion for comparing an [Expression] with its platform-specific equivalent.
+ *
+ * @param expression The expression to compare. An appropriate `toMapbox()` method will be called for comparison to [platform]
+ * @param platform The expected platform-specific value that [expression] should equal after being converted
+ * @param message A message to display if the assertion fails
+ */
+actual fun assertMapboxEquivalent(
+    expression: Expression,
+    platform: Any,
+    message: String?
+) {
+    assertEquals(expression.toMapbox(), platform as MapboxExpression, message)
+}

--- a/mapbox/src/commonMain/kotlin/com/cuhacking/mapbox/expressions/Expression.kt
+++ b/mapbox/src/commonMain/kotlin/com/cuhacking/mapbox/expressions/Expression.kt
@@ -1,0 +1,5 @@
+package com.cuhacking.mapbox.expressions
+
+open class Expression internal constructor(val operator: String?, vararg val arguments: Expression) {
+    internal constructor() : this(null)
+}

--- a/mapbox/src/commonMain/kotlin/com/cuhacking/mapbox/expressions/ExpressionLiteral.kt
+++ b/mapbox/src/commonMain/kotlin/com/cuhacking/mapbox/expressions/ExpressionLiteral.kt
@@ -1,0 +1,13 @@
+package com.cuhacking.mapbox.expressions
+
+class ExpressionLiteral internal constructor(public val literal: Any) : Expression()
+
+public fun literal(number: Number): Expression = ExpressionLiteral(number)
+
+public fun literal(string: String): Expression = ExpressionLiteral(string)
+
+public fun literal(boolean: Boolean): Expression = ExpressionLiteral(boolean)
+
+public fun literal(any: Any): Expression = ExpressionLiteral(any)
+
+public fun literal(array: Array<out Any>): Expression = ExpressionLiteral(array)

--- a/mapbox/src/commonTest/kotlin/com/cuhacking/mapbox/expressions/ExpressionLiteralTests.kt
+++ b/mapbox/src/commonTest/kotlin/com/cuhacking/mapbox/expressions/ExpressionLiteralTests.kt
@@ -1,0 +1,7 @@
+package com.cuhacking.mapbox.expressions
+
+expect class ExpressionLiteralTests {
+    fun testLiteralNumberMapping()
+
+    fun testLiteralStringMapping()
+}

--- a/mapbox/src/commonTest/kotlin/com/cuhacking/mapbox/expressions/ExpressionLiteralTests.kt
+++ b/mapbox/src/commonTest/kotlin/com/cuhacking/mapbox/expressions/ExpressionLiteralTests.kt
@@ -1,7 +1,22 @@
 package com.cuhacking.mapbox.expressions
 
-expect class ExpressionLiteralTests {
-    fun testLiteralNumberMapping()
+import com.cuhacking.mapbox.test.assertMapboxEquivalent
+import kotlin.test.Test
 
-    fun testLiteralStringMapping()
+expect object Literals {
+    fun number(number: Number): Any
+
+    fun string(string: String): Any
+}
+
+class ExpressionLiteralTests {
+    @Test
+    fun testLiteralNumberMapping() {
+        assertMapboxEquivalent(literal(64), Literals.number(64))
+    }
+
+    @Test
+    fun testLiteralStringMapping() {
+        assertMapboxEquivalent(literal("Hello World"), Literals.string("Hello World"))
+    }
 }

--- a/mapbox/src/commonTest/kotlin/com/cuhacking/mapbox/test/MapboxAssertions.kt
+++ b/mapbox/src/commonTest/kotlin/com/cuhacking/mapbox/test/MapboxAssertions.kt
@@ -1,0 +1,12 @@
+package com.cuhacking.mapbox.test
+
+import com.cuhacking.mapbox.expressions.Expression
+
+/**
+ * Utility assertion for comparing an [Expression] with its platform-specific equivalent.
+ *
+ * @param expression The expression to compare. An appropriate `toMapbox()` method will be called for comparison to [platform]
+ * @param platform The expected platform-specific value that [expression] should equal after being converted
+ * @param message A message to display if the assertion fails
+ */
+expect fun assertMapboxEquivalent(expression: Expression, platform: Any, message: String? = null)

--- a/mapbox/src/iosMain/kotlin/com/cuhacking/mapbox/expressions/Expression.kt
+++ b/mapbox/src/iosMain/kotlin/com/cuhacking/mapbox/expressions/Expression.kt
@@ -1,5 +1,8 @@
 package com.cuhacking.mapbox.expressions
 
-fun Expression.toMapbox() {
-    TODO("Not yet implemented. Still have't figured out how this translation will work")
+import platform.Foundation.NSExpression
+
+fun Expression.toNSExpression(): NSExpression = when (this) {
+    is ExpressionLiteral -> NSExpression.expressionForConstantValue(literal)
+    else -> TODO("Not yet implemented")
 }

--- a/mapbox/src/iosMain/kotlin/com/cuhacking/mapbox/expressions/Expression.kt
+++ b/mapbox/src/iosMain/kotlin/com/cuhacking/mapbox/expressions/Expression.kt
@@ -1,0 +1,5 @@
+package com.cuhacking.mapbox.expressions
+
+fun Expression.toMapbox() {
+    TODO("Not yet implemented. Still have't figured out how this translation will work")
+}

--- a/mapbox/src/iosTest/kotlin/com/cuhacking/mapbox/expressions/ExpressionLiteralTests.kt
+++ b/mapbox/src/iosTest/kotlin/com/cuhacking/mapbox/expressions/ExpressionLiteralTests.kt
@@ -1,0 +1,12 @@
+package com.cuhacking.mapbox.expressions
+
+import kotlin.test.Test
+
+
+actual class ExpressionLiteralTests {
+    @Test
+    actual fun testLiteralNumberMapping() {}
+
+    @Test
+    actual fun testLiteralStringMapping() {}
+}

--- a/mapbox/src/iosTest/kotlin/com/cuhacking/mapbox/expressions/ExpressionLiteralTests.kt
+++ b/mapbox/src/iosTest/kotlin/com/cuhacking/mapbox/expressions/ExpressionLiteralTests.kt
@@ -1,12 +1,16 @@
 package com.cuhacking.mapbox.expressions
 
-import kotlin.test.Test
 
+actual object Literals {
+    actual fun number(number: Number): Any {
+        // TODO("Not yet implemented")
 
-actual class ExpressionLiteralTests {
-    @Test
-    actual fun testLiteralNumberMapping() {}
+        return Any()
+    }
 
-    @Test
-    actual fun testLiteralStringMapping() {}
+    actual fun string(string: String): Any {
+        // TODO("Not yet implemented")
+
+        return Any()
+    }
 }

--- a/mapbox/src/iosTest/kotlin/com/cuhacking/mapbox/expressions/ExpressionLiteralTests.kt
+++ b/mapbox/src/iosTest/kotlin/com/cuhacking/mapbox/expressions/ExpressionLiteralTests.kt
@@ -1,16 +1,10 @@
 package com.cuhacking.mapbox.expressions
 
+import platform.Foundation.NSExpression
+
 
 actual object Literals {
-    actual fun number(number: Number): Any {
-        // TODO("Not yet implemented")
+    actual fun number(number: Number): Any = NSExpression.expressionForConstantValue(number)
 
-        return Any()
-    }
-
-    actual fun string(string: String): Any {
-        // TODO("Not yet implemented")
-
-        return Any()
-    }
+    actual fun string(string: String): Any = NSExpression.expressionForConstantValue(string)
 }

--- a/mapbox/src/iosTest/kotlin/com/cuhacking/mapbox/test/MapboxAssertions.kt
+++ b/mapbox/src/iosTest/kotlin/com/cuhacking/mapbox/test/MapboxAssertions.kt
@@ -1,6 +1,8 @@
 package com.cuhacking.mapbox.test
 
 import com.cuhacking.mapbox.expressions.Expression
+import com.cuhacking.mapbox.expressions.toNSExpression
+import kotlin.test.assertEquals
 
 /**
  * Utility assertion for comparing an [Expression] with its platform-specific equivalent.
@@ -14,5 +16,5 @@ actual fun assertMapboxEquivalent(
     platform: Any,
     message: String?
 ) {
-    // TODO: Implement appropriate assertion here
+    assertEquals(platform, expression.toNSExpression())
 }

--- a/mapbox/src/iosTest/kotlin/com/cuhacking/mapbox/test/MapboxAssertions.kt
+++ b/mapbox/src/iosTest/kotlin/com/cuhacking/mapbox/test/MapboxAssertions.kt
@@ -1,0 +1,18 @@
+package com.cuhacking.mapbox.test
+
+import com.cuhacking.mapbox.expressions.Expression
+
+/**
+ * Utility assertion for comparing an [Expression] with its platform-specific equivalent.
+ *
+ * @param expression The expression to compare. An appropriate `toMapbox()` method will be called for comparison to [platform]
+ * @param platform The expected platform-specific value that [expression] should equal after being converted
+ * @param message A message to display if the assertion fails
+ */
+actual fun assertMapboxEquivalent(
+    expression: Expression,
+    platform: Any,
+    message: String?
+) {
+    // TODO: Implement appropriate assertion here
+}

--- a/mapbox/src/jsMain/kotlin/com/cuhacking/mapbox/expressions/Expression.kt
+++ b/mapbox/src/jsMain/kotlin/com/cuhacking/mapbox/expressions/Expression.kt
@@ -1,0 +1,6 @@
+package com.cuhacking.mapbox.expressions
+
+fun Expression.toMapbox(): Array<Any> = when(this) {
+    is ExpressionLiteral -> arrayOf("literal", literal)
+    else -> arrayOf(operator!!, *arguments.map(Expression::toMapbox).toTypedArray())
+}

--- a/mapbox/src/jsTest/kotlin/com/cuhacking/mapbox/expressions/ExpressionLiteralTests.kt
+++ b/mapbox/src/jsTest/kotlin/com/cuhacking/mapbox/expressions/ExpressionLiteralTests.kt
@@ -1,0 +1,21 @@
+package com.cuhacking.mapbox.expressions
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+actual class ExpressionLiteralTests {
+    @Test
+    actual fun testLiteralNumberMapping() {
+        val value = literal(64)
+
+        assertTrue(value.toMapbox() contentEquals arrayOf<Any>("literal", 64))
+    }
+
+    @Test
+    actual fun testLiteralStringMapping() {
+        val value = literal("Hello World")
+
+        assertTrue(value.toMapbox() contentEquals arrayOf<Any>("literal", "Hello World"))
+    }
+}

--- a/mapbox/src/jsTest/kotlin/com/cuhacking/mapbox/expressions/ExpressionLiteralTests.kt
+++ b/mapbox/src/jsTest/kotlin/com/cuhacking/mapbox/expressions/ExpressionLiteralTests.kt
@@ -1,21 +1,8 @@
 package com.cuhacking.mapbox.expressions
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
-actual class ExpressionLiteralTests {
-    @Test
-    actual fun testLiteralNumberMapping() {
-        val value = literal(64)
+actual object Literals {
+    actual fun number(number: Number): Any = arrayOf("literal", 64)
 
-        assertTrue(value.toMapbox() contentEquals arrayOf<Any>("literal", 64))
-    }
-
-    @Test
-    actual fun testLiteralStringMapping() {
-        val value = literal("Hello World")
-
-        assertTrue(value.toMapbox() contentEquals arrayOf<Any>("literal", "Hello World"))
-    }
+    actual fun string(string: String): Any = arrayOf("literal", "Hello World")
 }

--- a/mapbox/src/jsTest/kotlin/com/cuhacking/mapbox/test/assertMapboxEquivalent.kt
+++ b/mapbox/src/jsTest/kotlin/com/cuhacking/mapbox/test/assertMapboxEquivalent.kt
@@ -1,0 +1,20 @@
+package com.cuhacking.mapbox.test
+
+import com.cuhacking.mapbox.expressions.Expression
+import com.cuhacking.mapbox.expressions.toMapbox
+import kotlin.test.assertTrue
+
+/**
+ * Utility assertion for comparing an [Expression] with its platform-specific equivalent.
+ *
+ * @param expression The expression to compare. An appropriate `toMapbox()` method will be called for comparison to [platform]
+ * @param platform The expected platform-specific value that [expression] should equal after being converted
+ * @param message A message to display if the assertion fails
+ */
+actual fun assertMapboxEquivalent(
+    expression: Expression,
+    platform: Any,
+    message: String?
+) {
+    assertTrue(expression.toMapbox() contentDeepEquals platform as Array<*>, message)
+}


### PR DESCRIPTION
Closes #4 

This only covers expression literals. For more complex expressions, Android and JS are largely covered, but iOS will require more specialized code because of the conversion to `NSExpression`.