### PR TITLE
Append wildcard character to FTS match

### DIFF
--- a/common/src/commonMain/sqldelight/com/cuhacking/atlas/db/Feature.sq
+++ b/common/src/commonMain/sqldelight/com/cuhacking/atlas/db/Feature.sq
@@ -45,7 +45,7 @@ DELETE FROM feature;
 search:
 SELECT *
 FROM feature_fts
-WHERE feature_fts MATCH ?;
+WHERE feature_fts MATCH ? || '*';
 
 clearFts:
 DELETE FROM feature_fts;

--- a/common/src/commonTest/kotlin/com/cuhacking/atlas/db/DatabaseTest.kt
+++ b/common/src/commonTest/kotlin/com/cuhacking/atlas/db/DatabaseTest.kt
@@ -36,7 +36,7 @@ class DatabaseTest : TestWithDatabase() {
         database.featureQueries.insertFeature(feature3)
 
         assertTrue(
-            database.featureQueries.search("HS 1301B").executeAsList()
+            database.featureQueries.search("HS").executeAsList()
                 .contains(feature3.toFTS())
         )
     }


### PR DESCRIPTION
Fixes #82 

This allows the search to match any results that _start_ with the query string.  
e.g. Previously if you typed `'R'` it would not match "RB". Now, the query becomes `'R*'` which allows it to match "RB".